### PR TITLE
Update Grapple.Plug and extend broadcast fn to check for body

### DIFF
--- a/lib/grapple/plug.ex
+++ b/lib/grapple/plug.ex
@@ -1,13 +1,17 @@
 defmodule Grapple.Plug do
   alias Grapple.Hook
+  import Plug.Conn
 
   def init(opts) do
-    Keyword.fetch! opts, :topic
+    topic = Keyword.fetch! opts, :topic
+    body = Keyword.get(opts, :body)
+
+    {topic, body}
   end
 
-  # TODO: need to revisit
-  def call(conn, topic, body) do
+  def call(conn, {topic, body}) do
     resp = Hook.broadcast topic, body
-    conn
+
+    assign(conn, :hook_responses, resp)
   end
 end

--- a/test/grapple_test.exs
+++ b/test/grapple_test.exs
@@ -46,7 +46,7 @@ defmodule GrappleTest do
 
     test "sends a successful hook", %{hook: hook} do
       Hook.subscribe hook
-      [resp] = Hook.broadcast hook.topic, nil
+      [resp] = Hook.broadcast hook.topic
 
       assert {:success, body: _body} = resp
     end
@@ -55,7 +55,7 @@ defmodule GrappleTest do
       hook = Map.put(hook, :url, "NOT_FOUND")
       Hook.subscribe hook
 
-      [resp] = Hook.broadcast hook.topic, nil
+      [resp] = Hook.broadcast hook.topic
 
       assert resp == :not_found
     end
@@ -64,7 +64,7 @@ defmodule GrappleTest do
       hook = Map.put(hook, :url, "ERROR")
       Hook.subscribe hook
 
-      [resp] = Hook.broadcast hook.topic, nil
+      [resp] = Hook.broadcast hook.topic
 
       assert {:error, reason: _} = resp
     end
@@ -76,7 +76,7 @@ defmodule GrappleTest do
 
     test "works" do
       defmodule Hookable do
-        defhook testing, do: :ok
+        defhook testing(), do: :ok
       end
 
       res = Hookable.testing()

--- a/test/http_client.exs
+++ b/test/http_client.exs
@@ -10,12 +10,14 @@ defmodule Grapple.Test.HttpClient do
     {:ok, %{status_code: 200, body: %{}}}
   end
 
-  def post(_url, _headers, _body) do
-    {:ok, %{status_code: 200, body: %{}}}
+  def post(_url, _headers, body) do
+    {:ok, %{status_code: 200, body: body}}
   end
-  def put(_url, _headers, _body) do
-    {:ok, %{status_code: 200, body: %{}}}
+
+  def put(_url, _headers, body) do
+    {:ok, %{status_code: 200, body: body}}
   end
+
   def delete(_url, _headers) do
     {:ok, %{status_code: 200, body: %{}}}
   end

--- a/test/plug_test.exs
+++ b/test/plug_test.exs
@@ -1,19 +1,23 @@
 defmodule Grapple.PlugTest do
   use ExUnit.Case, async: true
+  use Plug.Test
   alias Grapple.Hook
 
-  @params [topic: "stuff"]
+  @opts Grapple.Plug.init([topic: "stuff"])
 
   setup do
     Hook.clear_webhooks
     hook = %Hook{topic: "stuff", url: "elixir-lang.org"}
     Hook.subscribe(hook)
-    conn = %Plug.Conn{}
+    conn = conn(:get, "/hello")
 
     [hook: hook, conn: conn]
   end
 
   test "hook triggers on call", %{conn: conn} do
-    assert Grapple.Plug.call(conn, @params, nil)
+    conn = Grapple.Plug.call(conn, @opts)
+
+    assert conn.assigns.hook_responses
+    assert length(conn.assigns.hook_responses) > 0
   end
 end


### PR DESCRIPTION
References #3 

Update `broadcast` definition to ensure that if `nil` is passed as the second argument to `broadcast/2`, then the webhooks won't get sent with `nil` as the body, but rather with whatever the default `body` is on any individual `Hook` struct. This can help prevent a situation where a function defined with `defhook` that does not return anything, or a call to `Grapple.Plug` that does not include a `body` in its options will not cause _all_ webhooks for that `topic` to be sent with `nil` as the body. With `broadcast/1` we'll also avoid breaking changes on our next release :+1: 
