### PR TITLE
Response Logger v1

### DIFF
--- a/lib/grapple/hook.ex
+++ b/lib/grapple/hook.ex
@@ -45,6 +45,13 @@ defmodule Grapple.Hook do
   end
 
   @doc """
+  Returns all topics.
+  """
+  def get_topics do
+    GenServer.call __MODULE__, :get_topics
+  end
+
+  @doc """
   Executes an HTTP request for every Webhook of the
   specified topic.
   """
@@ -99,6 +106,13 @@ defmodule Grapple.Hook do
 
   def handle_call(:get_webhooks, _from, state = {webhooks, _stash_pid}) do
     {:reply, webhooks, state}
+  end
+
+  def handle_call(:get_topics, _from, state = {webhooks, _status_pid}) do
+    topics = webhooks
+      |> Enum.map(&(&1.topic))
+
+    {:reply, topics, state}
   end
 
   def handle_call({:broadcast, topic}, _from, {webhooks, stash_pid}) do

--- a/lib/grapple/logger.ex
+++ b/lib/grapple/logger.ex
@@ -1,0 +1,68 @@
+defmodule Grapple.Logger do
+  @moduledoc """
+  This module is responsible for keeping track of webhook
+  responses.
+  """
+  use GenServer
+
+  alias Grapple.Hook
+
+  # GenServer API
+
+  def start_link(responses) do
+    GenServer.start_link __MODULE__, responses, name: __MODULE__
+  end
+
+  @doc """
+  Retrieves all current logs.
+  """
+  def get_logs do
+    GenServer.call __MODULE__, :get_logs
+  end
+
+  @doc """
+  Retrieves logs by hook key, val.
+  """
+  def get_logs(key, val) do
+    GenServer.call __MODULE__, {:get_logs, {key, val}}
+  end
+
+  @doc """
+  Adds a response to logs and returns response.
+  """
+  # TODO: Response struct
+  def add_log(response, hook = %Hook{}) do
+    GenServer.call __MODULE__, {:add_log, {response, hook}}
+  end
+
+  @doc """
+  Clears logs.
+  """
+  def clear_logs do
+    GenServer.cast __MODULE__, :clear_logs
+  end
+
+  # Callbacks
+
+  def handle_call(:get_logs, _from, logs) do
+    {:reply, logs, logs}
+  end
+
+  def handle_call({:get_logs, {key, val}}, _from, logs) do
+    filtered_logs = logs
+      |> Enum.filter(&(Map.get(&1.hook, key) == val))
+
+    {:reply, filtered_logs, logs}
+  end
+
+  def handle_call({:add_log, {response, hook}}, _from, logs) do
+    log = [%{hook: hook, response: response}]
+
+    {:reply, response, logs ++ log}
+  end
+
+  def handle_cast(:clear_logs, _logs) do
+    {:noreply, []}
+  end
+
+end

--- a/lib/grapple/logger.ex
+++ b/lib/grapple/logger.ex
@@ -4,6 +4,7 @@ defmodule Grapple.Logger do
   responses.
   """
   use GenServer
+  use Timex
 
   alias Grapple.Hook
 
@@ -56,7 +57,7 @@ defmodule Grapple.Logger do
   end
 
   def handle_call({:add_log, {response, hook}}, _from, logs) do
-    log = [%{hook: hook, response: response}]
+    log = [%{hook: hook, response: response, timestamp: Timex.now}]
 
     {:reply, response, logs ++ log}
   end

--- a/lib/grapple/supervisor.ex
+++ b/lib/grapple/supervisor.ex
@@ -11,6 +11,7 @@ defmodule Grapple.Supervisor do
 
   def start_workers(sup, webhooks) do
     {:ok, stash} = Supervisor.start_child(sup, worker(Grapple.Stash, [webhooks]))
+    Supervisor.start_child(sup, worker(Grapple.Logger, [[]]))
     Supervisor.start_child(sup, supervisor(Grapple.HookSupervisor, [stash]))
   end
 

--- a/mix.exs
+++ b/mix.exs
@@ -32,7 +32,7 @@ defmodule Grapple.Mixfile do
   # Type "mix help compile.app" for more information
   def application do
     [
-      applications: [:httpoison, :logger, :plug,],
+      applications: [:httpoison, :logger, :plug, :timex],
       mod: {Grapple, []},
     ]
   end
@@ -53,6 +53,7 @@ defmodule Grapple.Mixfile do
       {:uuid, "~> 1.1"},
       {:plug, "~> 1.2.0"},
       {:ex_doc, "~> 0.13", only: :dev},
+      {:timex, "~> 3.0"},
     ]
   end
 end

--- a/mix.lock
+++ b/mix.lock
@@ -1,6 +1,8 @@
 %{"certifi": {:hex, :certifi, "0.4.0", "a7966efb868b179023618d29a407548f70c52466bf1849b9e8ebd0e34b7ea11f", [:rebar3], []},
+  "combine": {:hex, :combine, "0.9.2", "cd3c8721f378ebe032487d8a4fa2ced3181a456a3c21b16464da8c46904bb552", [:mix], []},
   "earmark": {:hex, :earmark, "1.0.1", "2c2cd903bfdc3de3f189bd9a8d4569a075b88a8981ded9a0d95672f6e2b63141", [:mix], []},
   "ex_doc": {:hex, :ex_doc, "0.13.2", "1059a588d2ad3ffab25a0b85c58abf08e437d3e7a9124ac255e1d15cec68ab79", [:mix], [{:earmark, "~> 1.0", [hex: :earmark, optional: false]}]},
+  "gettext": {:hex, :gettext, "0.11.0", "80c1dd42d270482418fa158ec5ba073d2980e3718bacad86f3d4ad71d5667679", [:mix], []},
   "graphql": {:hex, :graphql, "0.3.1", "d3bb5467877456cc2b33debc75407e9216567b10e35e83d5195e2d51e835e8c7", [:mix], []},
   "hackney": {:hex, :hackney, "1.6.1", "ddd22d42db2b50e6a155439c8811b8f6df61a4395de10509714ad2751c6da817", [:rebar3], [{:certifi, "0.4.0", [hex: :certifi, optional: false]}, {:idna, "1.2.0", [hex: :idna, optional: false]}, {:metrics, "1.0.1", [hex: :metrics, optional: false]}, {:mimerl, "1.0.2", [hex: :mimerl, optional: false]}, {:ssl_verify_fun, "1.1.0", [hex: :ssl_verify_fun, optional: false]}]},
   "httpoison": {:hex, :httpoison, "0.9.1", "6c2b4eaf2588a6f3ef29663d28c992531ca3f0bc832a97e0359bc822978e1c5d", [:mix], [{:hackney, "~> 1.6.0", [hex: :hackney, optional: false]}]},
@@ -13,4 +15,6 @@
   "plug": {:hex, :plug, "1.2.0", "496bef96634a49d7803ab2671482f0c5ce9ce0b7b9bc25bc0ae8e09859dd2004", [:mix], [{:cowboy, "~> 1.0", [hex: :cowboy, optional: true]}, {:mime, "~> 1.0", [hex: :mime, optional: false]}]},
   "poison": {:hex, :poison, "2.2.0", "4763b69a8a77bd77d26f477d196428b741261a761257ff1cf92753a0d4d24a63", [:mix], []},
   "ssl_verify_fun": {:hex, :ssl_verify_fun, "1.1.0", "edee20847c42e379bf91261db474ffbe373f8acb56e9079acb6038d4e0bf414f", [:rebar, :make], []},
+  "timex": {:hex, :timex, "3.0.8", "71d5ebafcdc557c6c866cdc196c5054f587e7cd1118ad8937e2293d51fc85608", [:mix], [{:combine, "~> 0.7", [hex: :combine, optional: false]}, {:gettext, "~> 0.10", [hex: :gettext, optional: false]}, {:tzdata, "~> 0.1.8 or ~> 0.5", [hex: :tzdata, optional: false]}]},
+  "tzdata": {:hex, :tzdata, "0.5.9", "575be217b039057a47e133b72838cbe104fb5329b19906ea4e66857001c37edb", [:mix], [{:hackney, "~> 1.0", [hex: :hackney, optional: false]}]},
   "uuid": {:hex, :uuid, "1.1.4", "36c7734e4c8e357f2f67ba57fb61799d60c20a7f817b104896cca64b857e3686", [:mix], []}}

--- a/test/grapple_test.exs
+++ b/test/grapple_test.exs
@@ -1,9 +1,10 @@
 defmodule GrappleTest do
   use ExUnit.Case, async: true
-  alias Grapple.Hook
+  alias Grapple.{Hook, Logger}
 
   setup do
     Hook.clear_webhooks
+    Logger.clear_logs
 
     [hook: %Hook{topic: "stuff", url: "elixir-lang.org"}]
   end
@@ -53,7 +54,7 @@ defmodule GrappleTest do
 
     test "sends a successful hook", %{hook: hook} do
       Hook.subscribe hook
-      [resp] = Hook.broadcast hook.topic
+      [%{response: resp}] = Hook.broadcast hook.topic
 
       assert {:success, body: _body} = resp
     end
@@ -62,7 +63,7 @@ defmodule GrappleTest do
       hook = Map.put(hook, :url, "NOT_FOUND")
       Hook.subscribe hook
 
-      [resp] = Hook.broadcast hook.topic
+      [%{response: resp}] = Hook.broadcast hook.topic
 
       assert resp == :not_found
     end
@@ -71,7 +72,7 @@ defmodule GrappleTest do
       hook = Map.put(hook, :url, "ERROR")
       Hook.subscribe hook
 
-      [resp] = Hook.broadcast hook.topic
+      [%{response: resp}] = Hook.broadcast hook.topic
 
       assert {:error, reason: _} = resp
     end

--- a/test/grapple_test.exs
+++ b/test/grapple_test.exs
@@ -22,6 +22,13 @@ defmodule GrappleTest do
       assert ref == returned_hook.ref
     end
 
+    test "can get topics", %{hook: hook} do
+      Hook.subscribe hook
+      [topic] = Hook.get_topics
+
+      assert topic == "stuff"
+    end
+
     test "can remove a specified hook by ref", %{hook: hook} do
       {_topic, ref} = Hook.subscribe hook
       Hook.remove_webhook(ref)

--- a/test/logger_test.exs
+++ b/test/logger_test.exs
@@ -1,0 +1,42 @@
+defmodule Grapple.LoggerTest do
+  use ExUnit.Case, async: true
+  alias Grapple.{Hook, Logger}
+
+  setup do
+    Hook.clear_webhooks
+    Logger.clear_logs
+    hook = %Hook{topic: "stuff", url: "elixir-lang.org"}
+    {_topic, ref} = Hook.subscribe hook
+
+    [hook: hook, ref: ref]
+  end
+
+  describe "logger" do
+
+    test "can get logs" do
+      assert [] = Logger.get_logs
+    end
+
+    test "can add a log", %{hook: hook} do
+      Logger.add_log(%{}, hook)
+
+      assert [_log] = Logger.get_logs
+    end
+
+    test "broadcasting should add responses to the log", %{ref: ref} do
+      Hook.broadcast "stuff"
+
+      assert [%{hook: returned_hook}] = Logger.get_logs
+      assert ref == returned_hook.ref
+    end
+
+    test "filtering on logs", %{ref: ref} do
+      Hook.broadcast "stuff"
+
+      assert [%{hook: returned_hook}] = Logger.get_logs
+      assert ref == returned_hook.ref
+    end
+
+  end
+
+end


### PR DESCRIPTION
#5

This is a basic system that stores responses from webhook requests. Logs have a `response`, a `hook`, and a `timestamp`. Logs can be filtered by any key/val pair in the `hook` that triggered the request. Future steps might include integrating this with Elixir's [Logger](http://elixir-lang.org/docs/stable/logger/Logger.html#content) for more configurability.
