### PR TITLE
[ref #8] Integrated Experimental.Flow into Hook.broadcast 

### DIFF
--- a/lib/grapple/hook.ex
+++ b/lib/grapple/hook.ex
@@ -5,6 +5,7 @@ defmodule Grapple.Hook do
   for defining hooks.
   """
   use GenServer
+  alias Experimental.Flow, as: Flow
 
   @http Application.get_env(:grapple, :http)
 

--- a/lib/grapple/hook.ex
+++ b/lib/grapple/hook.ex
@@ -105,15 +105,20 @@ defmodule Grapple.Hook do
   def handle_call({:broadcast, topic}, _from, {webhooks, stash_pid}) do
     resp_log = webhooks
       |> Enum.filter(&(&1.topic == topic))
-      |> Enum.map(fn webhook -> notify(webhook, webhook.body) end)
+      |> Flow.from_enumerable()
+      |> Flow.map(fn webhook -> notify(webhook, webhook.body) end)
+      |> Enum.to_list()
 
     {:reply, resp_log, {webhooks, stash_pid}}
   end
 
+  # TODO: integrate Flow!
   def handle_call({:broadcast, {topic, body}}, _from, {webhooks, stash_pid}) do
     resp_log = webhooks
       |> Enum.filter(&(&1.topic == topic))
-      |> Enum.map(fn webhook -> notify(webhook, body) end)
+      |> Flow.from_enumerable()
+      |> Flow.map(fn webhook -> notify(webhook, body) end)
+      |> Enum.to_list()
 
     {:reply, resp_log, {webhooks, stash_pid}}
   end

--- a/lib/grapple/hook.ex
+++ b/lib/grapple/hook.ex
@@ -56,7 +56,7 @@ defmodule Grapple.Hook do
     GenServer.call __MODULE__, {:broadcast, topic}
   end
   def broadcast(topic, body) do
-    GenServer.call __MODULE__, {:broadcast, {topic, body}}
+    GenServer.call __MODULE__, {:broadcast, topic, body}
   end
 
   @doc """
@@ -103,24 +103,23 @@ defmodule Grapple.Hook do
   end
 
   def handle_call({:broadcast, topic}, _from, {webhooks, stash_pid}) do
-    resp_log = webhooks
+    responses = webhooks
       |> Enum.filter(&(&1.topic == topic))
       |> Flow.from_enumerable()
       |> Flow.map(fn webhook -> notify(webhook, webhook.body) end)
       |> Enum.to_list()
 
-    {:reply, resp_log, {webhooks, stash_pid}}
+    {:reply, responses, {webhooks, stash_pid}}
   end
 
-  # TODO: integrate Flow!
-  def handle_call({:broadcast, {topic, body}}, _from, {webhooks, stash_pid}) do
-    resp_log = webhooks
+  def handle_call({:broadcast, topic, body}, _from, {webhooks, stash_pid}) do
+    responses = webhooks
       |> Enum.filter(&(&1.topic == topic))
       |> Flow.from_enumerable()
       |> Flow.map(fn webhook -> notify(webhook, body) end)
       |> Enum.to_list()
 
-    {:reply, resp_log, {webhooks, stash_pid}}
+    {:reply, responses, {webhooks, stash_pid}}
   end
 
   def handle_cast({:remove_webhook, ref}, {webhooks, stash_pid}) do

--- a/mix.exs
+++ b/mix.exs
@@ -32,7 +32,7 @@ defmodule Grapple.Mixfile do
   # Type "mix help compile.app" for more information
   def application do
     [
-      applications: [:httpoison, :logger, :plug,],
+      applications: [:httpoison, :logger, :plug, :gen_stage],
       mod: {Grapple, []},
     ]
   end
@@ -52,6 +52,7 @@ defmodule Grapple.Mixfile do
       {:httpoison, "~> 0.9.0"},
       {:uuid, "~> 1.1"},
       {:plug, "~> 1.2.0"},
+      {:gen_stage, "~> 0.4"},
       {:ex_doc, "~> 0.13", only: :dev},
     ]
   end

--- a/mix.lock
+++ b/mix.lock
@@ -1,6 +1,7 @@
 %{"certifi": {:hex, :certifi, "0.4.0", "a7966efb868b179023618d29a407548f70c52466bf1849b9e8ebd0e34b7ea11f", [:rebar3], []},
   "earmark": {:hex, :earmark, "1.0.1", "2c2cd903bfdc3de3f189bd9a8d4569a075b88a8981ded9a0d95672f6e2b63141", [:mix], []},
   "ex_doc": {:hex, :ex_doc, "0.13.2", "1059a588d2ad3ffab25a0b85c58abf08e437d3e7a9124ac255e1d15cec68ab79", [:mix], [{:earmark, "~> 1.0", [hex: :earmark, optional: false]}]},
+  "gen_stage": {:hex, :gen_stage, "0.6.1", "1e05e3faf9e505dcdb1e6d2da501fc5d1724e7ea6176bf72853ea78c8a600d1c", [:mix], []},
   "graphql": {:hex, :graphql, "0.3.1", "d3bb5467877456cc2b33debc75407e9216567b10e35e83d5195e2d51e835e8c7", [:mix], []},
   "hackney": {:hex, :hackney, "1.6.1", "ddd22d42db2b50e6a155439c8811b8f6df61a4395de10509714ad2751c6da817", [:rebar3], [{:certifi, "0.4.0", [hex: :certifi, optional: false]}, {:idna, "1.2.0", [hex: :idna, optional: false]}, {:metrics, "1.0.1", [hex: :metrics, optional: false]}, {:mimerl, "1.0.2", [hex: :mimerl, optional: false]}, {:ssl_verify_fun, "1.1.0", [hex: :ssl_verify_fun, optional: false]}]},
   "httpoison": {:hex, :httpoison, "0.9.1", "6c2b4eaf2588a6f3ef29663d28c992531ca3f0bc832a97e0359bc822978e1c5d", [:mix], [{:hackney, "~> 1.6.0", [hex: :hackney, optional: false]}]},

--- a/test/grapple_test.exs
+++ b/test/grapple_test.exs
@@ -60,6 +60,15 @@ defmodule GrappleTest do
       assert resp == :not_found
     end
 
+    # test "sends a hook with a body", %{hook: hook} do
+    #   hook = Map.put(hook, :body, "works")
+    #   Hook.subscribe hook
+
+    #   [resp] = Hook.broadcast(hook.topic, hook.body)
+
+    #   assert {:success, body: _body} = resp
+    # end
+
     test "sends a hook and gets an error", %{hook: hook} do
       hook = Map.put(hook, :url, "ERROR")
       Hook.subscribe hook

--- a/test/grapple_test.exs
+++ b/test/grapple_test.exs
@@ -60,14 +60,14 @@ defmodule GrappleTest do
       assert resp == :not_found
     end
 
-    # test "sends a hook with a body", %{hook: hook} do
-    #   hook = Map.put(hook, :body, "works")
-    #   Hook.subscribe hook
+    test "sends a hook with a body", %{hook: hook} do
+      hook = Map.put(hook, :body, "works")
+      Hook.subscribe hook
 
-    #   [resp] = Hook.broadcast(hook.topic, hook.body)
+      [resp] = Hook.broadcast hook.topic, hook.body
 
-    #   assert {:success, body: _body} = resp
-    # end
+      assert {:success, body: _body} = resp
+    end
 
     test "sends a hook and gets an error", %{hook: hook} do
       hook = Map.put(hook, :url, "ERROR")


### PR DESCRIPTION
**Story**
- #8

**Changes**
- :art: integrates `Flow` into both `broadcast` methods, transparently parallelizing the HTTP calls that are made to each subscriber.

**Future**
- I would like to know more details as to how `Flow` is performing parallel execution here, there are many ways in which it could approach this but it is likely just splitting the tasks/process evenly across cores, generally trying to keep them balanced.
