### PR TITLE
Fix hook restart bug

### DIFF
--- a/lib/grapple/hook_server.ex
+++ b/lib/grapple/hook_server.ex
@@ -100,9 +100,11 @@ defmodule Grapple.HookServer do
       case {ref, pid} in monitors do
         true ->
           true = Process.demonitor(ref)
+          [{^pid, hook}] = :ets.lookup(hooks, pid)
           true = :ets.delete(hooks, pid)
           new_monitors = List.delete(monitors, {ref, pid})
-          new_state = %{state | monitors: new_monitors}
+          new_hook = add_hook(hooks, hook, hook_sup)
+          new_state = %{state | monitors: [new_monitors]}
 
           {:noreply, new_state}
         _ ->

--- a/lib/grapple/hook_supervisor.ex
+++ b/lib/grapple/hook_supervisor.ex
@@ -9,7 +9,7 @@ defmodule Grapple.HookSupervisor do
   end
 
   def init(_) do
-    opts = [restart: :permanent]
+    opts = [restart: :temporary]
     children = [worker(Grapple.Hook, [], opts)]
     supervise children, strategy: :simple_one_for_one
   end

--- a/lib/grapple/server.ex
+++ b/lib/grapple/server.ex
@@ -2,8 +2,6 @@ defmodule Grapple.Server do
   @moduledoc false
   use GenServer
 
-  @backend Application.get_env(:grapple, :backend) || Grapple.Ets
-
   defmodule Topic do
     defstruct [:sup, :name,]
   end


### PR DESCRIPTION
Previously, when hooks would fail, the `HookSupervisor` would
restart the hook, but the `HookServer` would not have knowledge
of this and would therefore have no `hooks` entries even though
one in fact existed. This fix will make sure that hooks get
restarted, and that the `HookServer` is also aware of them,
as it will restart them itself.